### PR TITLE
Add Windows helper script for CGH Mask Designer

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ python -m pip install -e .
 python -m cgh_mask_designer
 ```
 
+### Windows helper script
+
+Windows users can double-click `run_cgh_mask_designer.cmd` (at the repository
+root) to create/activate a local `.venv`, install the package, and launch the
+application. The script leaves the command prompt window open after the
+application exits so any error messages remain visible.
+
 The UI is powered by PyQt6. On Windows and macOS the required Qt libraries
 are bundled with the PyPI wheels. On Linux you may need the system's Qt
 platform plugins (e.g., XCB/Wayland packages) available so the application

--- a/run_cgh_mask_designer.cmd
+++ b/run_cgh_mask_designer.cmd
@@ -1,0 +1,38 @@
+@echo off
+setlocal
+
+REM Change to the directory containing this script
+cd /d "%~dp0"
+
+REM Ensure a virtual environment exists
+if not exist .venv (
+    echo [CGH Mask Designer] Creating virtual environment in .venv
+    python -m venv .venv
+    if errorlevel 1 goto :error
+)
+
+REM Activate the virtual environment
+call .venv\Scripts\activate
+if errorlevel 1 goto :error
+
+REM Upgrade pip to the latest version
+python -m pip install --upgrade pip
+if errorlevel 1 goto :error
+
+REM Install the CGH Mask Designer package into the virtual environment
+python -m pip install .
+if errorlevel 1 goto :error
+
+REM Launch the application
+python -m cgh_mask_designer
+if errorlevel 1 goto :error
+
+goto :end
+
+:error
+echo.
+echo [CGH Mask Designer] An error occurred. See messages above for details.
+
+:end
+echo.
+pause


### PR DESCRIPTION
## Summary
- add a Windows command script that provisions a local virtual environment, installs the package, and launches the app while leaving the console open
- mention the helper script in the README so Windows users can find it

## Testing
- not run (script only)


------
https://chatgpt.com/codex/tasks/task_e_68d00b1a646c83248a3115eeaeb632bb