### PR TITLE
Use QSettings from QtCore in main window

### DIFF
--- a/cgh_mask_designer/ui/main_window.py
+++ b/cgh_mask_designer/ui/main_window.py
@@ -1,5 +1,5 @@
 from PyQt6 import QtWidgets, QtGui
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import Qt, QSettings
 import numpy as np
 
 from ..core.settings import Settings
@@ -114,7 +114,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.auto_cb.setChecked(st.auto_update)
 
     def _load_qsettings(self):
-        qs = QtWidgets.QSettings("CGHMaskDesigner", "Main")
+        qs = QSettings("CGHMaskDesigner", "Main")
         blob = qs.value("settings_json", "")
         if blob:
             try:
@@ -124,7 +124,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 pass
 
     def _save_qsettings(self):
-        qs = QtWidgets.QSettings("CGHMaskDesigner", "Main")
+        qs = QSettings("CGHMaskDesigner", "Main")
         qs.setValue("settings_json", self.st.to_json())
 
     def export_json(self):


### PR DESCRIPTION
## Summary
- import QSettings from PyQt6.QtCore so the main window pulls the class from the correct module
- update the main window to instantiate QSettings directly instead of via QtWidgets

## Testing
- QT_QPA_PLATFORM=offscreen python -m cgh_mask_designer *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68d00ee661348324b92fa0f2ef7906c1