### PR TITLE
Add SVG target image loading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,6 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
   "PyQt6",
+  "PyQt6-Qt6-Svg",
   "numpy",
 ]


### PR DESCRIPTION
## Summary
- include the QtSvg runtime wheel in the project dependencies so the SVG renderer is available at runtime
- import QSvgRenderer and add logic to render SVG files into grayscale images that match the target canvas
- allow SVG files to be picked in the image dialog while keeping the existing raster image loading path intact

## Testing
- python -m compileall cgh_mask_designer

------
https://chatgpt.com/codex/tasks/task_e_68d0161876f48324a30bf1b9c067374a