### PR TITLE
Restrict setuptools package discovery to app module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,6 @@ dependencies = [
   "PyQt6-Qt6-Svg",
   "numpy",
 ]
+
+[tool.setuptools.packages.find]
+include = ["cgh_mask_designer"]


### PR DESCRIPTION
## Summary
- limit setuptools package discovery to the cgh_mask_designer package to avoid including test assets in the wheel

## Testing
- `python -m pip install .` *(fails: dependency PyQt6-Qt6-Svg is unavailable in the environment, but the wheel now builds until dependency resolution)*

------
https://chatgpt.com/codex/tasks/task_e_68d01928ae788324a916b0603e01731e