### PR TITLE
Remove unused PyQt6 SVG dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
   "PyQt6",
-  "PyQt6-Qt6-Svg",
   "numpy",
 ]
 


### PR DESCRIPTION
## Summary
- drop the unused PyQt6-Qt6-Svg package from the install dependencies since the app only relies on PyQt6 and numpy

## Testing
- python -m pip install .

------
https://chatgpt.com/codex/tasks/task_e_68d01e738f108324ac954e8b38cde105