### PR TITLE
Ensure settings persist when auto update is disabled

### DIFF
--- a/cgh_mask_designer/ui/main_window.py
+++ b/cgh_mask_designer/ui/main_window.py
@@ -128,6 +128,11 @@ class MainWindow(QtWidgets.QMainWindow):
         qs = QSettings("CGHMaskDesigner", "Main")
         qs.setValue("settings_json", self.st.to_json())
 
+    def closeEvent(self, event):
+        self.pull_settings()
+        self._save_qsettings()
+        super().closeEvent(event)
+
     def export_json(self):
         fn, _ = QtWidgets.QFileDialog.getSaveFileName(self, "Export settings", "settings.json", "JSON (*.json)")
         if fn:
@@ -216,6 +221,9 @@ class MainWindow(QtWidgets.QMainWindow):
     def maybe_auto(self, *args):
         if self.auto_cb.isChecked():
             self.update_all()
+        elif self.sender() is self.auto_cb:
+            self.pull_settings()
+            self._save_qsettings()
 
     def update_all(self):
         self.pull_settings()


### PR DESCRIPTION
## Summary
- persist widget values when the window closes by saving settings in the close event handler
- update the auto-update toggle callback to flush settings when the checkbox is turned off so its state is remembered immediately

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d028cbe420832485ac7604f9d56424