### PR TITLE
Center raster targets on canvas

### DIFF
--- a/cgh_mask_designer/ui/main_window.py
+++ b/cgh_mask_designer/ui/main_window.py
@@ -209,10 +209,26 @@ class MainWindow(QtWidgets.QMainWindow):
                 painter.end()
             img = img.convertToFormat(QtGui.QImage.Format.Format_Grayscale8)
         else:
-            img = QtGui.QImage(fn)
-            if img.isNull(): return
-            img = img.convertToFormat(QtGui.QImage.Format.Format_Grayscale8)
-            img = img.scaled(self.st.width_px, self.st.height_px, Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation)
+            src = QtGui.QImage(fn)
+            if src.isNull():
+                return
+            src = src.convertToFormat(QtGui.QImage.Format.Format_Grayscale8)
+            canvas = QtGui.QImage(self.st.width_px, self.st.height_px, QtGui.QImage.Format.Format_Grayscale8)
+            canvas.fill(Qt.GlobalColor.white)
+            scaled = src.scaled(
+                self.st.width_px,
+                self.st.height_px,
+                Qt.AspectRatioMode.KeepAspectRatio,
+                Qt.TransformationMode.SmoothTransformation,
+            )
+            painter = QtGui.QPainter(canvas)
+            try:
+                x = int((canvas.width() - scaled.width()) / 2)
+                y = int((canvas.height() - scaled.height()) / 2)
+                painter.drawImage(x, y, scaled)
+            finally:
+                painter.end()
+            img = canvas
         ptr = img.bits(); ptr.setsize(img.height()*img.bytesPerLine())
         arr = np.frombuffer(ptr, np.uint8).reshape((img.height(), img.bytesPerLine()))[:, :img.width()].copy()
         self.target = arr.astype(np.float32)/255.0


### PR DESCRIPTION
## Summary
- draw non-SVG raster targets onto a grayscale canvas that matches the configured mask size before converting to numpy
- preserve the target array dimensions so the update pipeline keeps the loaded raster data

## Testing
- python -m compileall cgh_mask_designer
- python - <<'PY'
import os
os.environ["QT_QPA_PLATFORM"] = "offscreen"
from PyQt6 import QtWidgets, QtGui
from cgh_mask_designer.core.settings import Settings
from cgh_mask_designer.ui.main_window import MainWindow
import numpy as np

# Create a rectangular test image
img = QtGui.QImage(300, 150, QtGui.QImage.Format.Format_RGB32)
img.fill(QtGui.QColor("white"))
p = QtGui.QPainter(img)
p.fillRect(50, 25, 200, 100, QtGui.QColor("black"))
p.end()
path = "rect_test.png"
img.save(path)

app = QtWidgets.QApplication([])
QtWidgets.QFileDialog.getOpenFileName = lambda *args, **kwargs: (path, "")
st = Settings()
st.auto_update = False
w = MainWindow(st)
w.hide()
w.load_target()

arr = w.target
print("shape", arr.shape, "min", arr.min(), "max", arr.max())
rows = np.where(arr < 0.99)[0]
cols = np.where(arr < 0.99)[1]
print("target row bounds", rows.min(), rows.max())
print("target col bounds", cols.min(), cols.max())

mask = w.mask
rows_m = np.where(mask < mask.max())[0]
cols_m = np.where(mask < mask.max())[1]
print("mask row bounds", rows_m.min(), rows_m.max())
print("mask col bounds", cols_m.min(), cols_m.max())

app.quit()
PY


------
https://chatgpt.com/codex/tasks/task_e_68d02a295f108324a1832dd98e487767