### PR TITLE
Handle sub-pixel dots in size modulation preview

### DIFF
--- a/cgh_mask_designer/core/encoding.py
+++ b/cgh_mask_designer/core/encoding.py
@@ -32,6 +32,7 @@ def raster_size_modulation(img: np.ndarray, min_d_um: float, max_d_um: float, um
     cx0 = (W - (nx-1)*pitch_px)/2 if nx>1 else W/2
     cy0 = (H - (ny-1)*pitch_px)/2 if ny>1 else H/2
     yy, xx = np.mgrid[0:H, 0:W]
+    x_samples = np.linspace(-0.5, 0.5, 256, dtype=np.float32)
     for j in range(ny):
         for i in range(nx):
             cx = cx0 + i*pitch_px
@@ -41,7 +42,24 @@ def raster_size_modulation(img: np.ndarray, min_d_um: float, max_d_um: float, um
             val = float(img[ix, iy])
             d_um = min_d_um + val*(max_d_um - min_d_um)
             r_px = 0.5 * (d_um / um_per_px)
-            if r_px <= 0.5: continue
+            if r_px <= 0.5:
+                dx = cx - iy
+                dy = cy - ix
+                r2 = r_px * r_px
+                rel_x = x_samples - dx
+                inside = rel_x * rel_x < r2
+                if np.any(inside):
+                    vertical = np.sqrt(np.maximum(0.0, r2 - rel_x[inside] * rel_x[inside]))
+                    y_low = dy - vertical
+                    y_high = dy + vertical
+                    y1 = np.maximum(-0.5, y_low)
+                    y2 = np.minimum(0.5, y_high)
+                    height = np.maximum(0.0, y2 - y1)
+                    if np.any(height > 0.0):
+                        coverage = float(np.trapz(height, x_samples[inside]))
+                        if coverage > 0.0:
+                            out[ix, iy] = max(out[ix, iy], min(1.0, coverage))
+                continue
             rr2 = (xx-cx)**2 + (yy-cy)**2
             out = np.maximum(out, (rr2 <= r_px*r_px).astype(np.float32))
     return out


### PR DESCRIPTION
## Summary
- add a fractional coverage estimate to `raster_size_modulation` so apertures smaller than half a pixel still contribute to the raster mask

## Testing
- python -m compileall cgh_mask_designer
- python - <<'PY' ... (JSON size modulation settings sanity check)
- python - <<'PY' ... (coverage agreement check)


------
https://chatgpt.com/codex/tasks/task_e_68d03ae990388324905c4465552d832c