### PR TITLE
Add reconstruction SVG export option

### DIFF
--- a/cgh_mask_designer/ui/controls/io_panel.py
+++ b/cgh_mask_designer/ui/controls/io_panel.py
@@ -1,19 +1,22 @@
 from PyQt6 import QtWidgets
 
 class IOPanel(QtWidgets.QWidget):
-    def __init__(self, st, on_export_settings, on_import_settings, on_export_svg, on_save_pngs):
+    def __init__(self, st, on_export_settings, on_import_settings, on_export_svg, on_export_recon_svg, on_save_pngs):
         super().__init__()
         lay = QtWidgets.QVBoxLayout(self)
         self.save_svg_btn = QtWidgets.QPushButton("Export Mask as SVG…")
+        self.save_recon_svg_btn = QtWidgets.QPushButton("Export Reconstruction as SVG…")
         self.save_png_btn = QtWidgets.QPushButton("Save Previews (PNG)…")
         self.save_json_btn = QtWidgets.QPushButton("Export Settings (JSON)…")
         self.load_json_btn = QtWidgets.QPushButton("Import Settings (JSON)…")
         lay.addWidget(self.save_svg_btn)
+        lay.addWidget(self.save_recon_svg_btn)
         lay.addWidget(self.save_png_btn)
         lay.addWidget(self.save_json_btn)
         lay.addWidget(self.load_json_btn)
         lay.addStretch(1)
         self.save_svg_btn.clicked.connect(on_export_svg)
+        self.save_recon_svg_btn.clicked.connect(on_export_recon_svg)
         self.save_png_btn.clicked.connect(on_save_pngs)
         self.save_json_btn.clicked.connect(on_export_settings)
         self.load_json_btn.clicked.connect(on_import_settings)

--- a/cgh_mask_designer/ui/main_window.py
+++ b/cgh_mask_designer/ui/main_window.py
@@ -36,7 +36,14 @@ class MainWindow(QtWidgets.QMainWindow):
         self.target_panel = TargetPanel(self.st, self.maybe_auto)
         self.optics_panel = OpticsPanel(self.st, self.maybe_auto)
         self.encoding_panel = EncodingPanel(self.st, self.maybe_auto)
-        self.io_panel = IOPanel(self.st, self.export_json, self.import_json, self.export_svg, self.save_previews)
+        self.io_panel = IOPanel(
+            self.st,
+            self.export_json,
+            self.import_json,
+            self.export_svg,
+            self.export_reconstruction_svg,
+            self.save_previews,
+        )
 
         tabs.addTab(self.target_panel, "Target")
         tabs.addTab(self.optics_panel, "Optics")
@@ -176,6 +183,25 @@ class MainWindow(QtWidgets.QMainWindow):
         else:
             step = max(1, int(round(self.st.grid_pitch_um / um_per_px)))
             export_svg_pixels(fn, self.mask, um_per_px, step)
+
+    def export_reconstruction_svg(self):
+        fn, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self,
+            "Export reconstruction SVG",
+            "reconstruction.svg",
+            "SVG (*.svg)",
+        )
+        if not fn:
+            return
+        if self.recon.size == 0:
+            return
+        recon = np.asarray(self.recon, dtype=np.float32)
+        recon = recon - float(recon.min())
+        mx = float(recon.max())
+        if mx > 0:
+            recon = recon / mx
+        um_per_px = self.st.um_per_px
+        export_svg_pixels(fn, recon, um_per_px, step=1)
 
     def load_target(self):
         fn, _ = QtWidgets.QFileDialog.getOpenFileName(self, "Open target image", "", "Images (*.png *.jpg *.bmp *.tif *.svg)")


### PR DESCRIPTION
## Summary
- add a reconstruction SVG export control in the I/O panel
- implement an export handler that normalizes the reconstruction and writes it via `export_svg_pixels`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d04ad3d1e08324b2bb712938e372aa